### PR TITLE
#43 Upgrade to Spring Cloud 2021.0 and Spring Boot 2.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This fork also demostrates the use of free distributed tracing with Tanzu Observ
 
 
   * [Understanding the Spring Petclinic application](#understanding-the-spring-petclinic-application)
-  * [Compiling and pushing to Cloud Foundry:](#compiling-and-pushing-to-cloud-foundry-)
+  * [Compiling and pushing to Cloud Foundry:](#compiling-and-pushing-to-cloud-foundry)
   * [Compiling and pushing to Kubernetes](#compiling-and-pushing-to-kubernetes)
     + [Choose your Docker registry](#choose-your-docker-registry)
     + [Setting things up in Kubernetes](#setting-things-up-in-kubernetes)
@@ -147,7 +147,7 @@ This get a little bit more complicated when deploying to Kubernetes, since we ne
 
 You need to define your target Docker registry. Make sure you're already logged in by running `docker login <endpoint>` or `docker login` if you're just targeting Docker hub.
 
-Setup an env varible to target your Docker registry. If you're targeting Docker hub, simple provide your username, for example:
+Setup an env variable to target your Docker registry. If you're targeting Docker hub, simple provide your username, for example:
 
 ```bash
 export REPOSITORY_PREFIX=odedia
@@ -284,7 +284,11 @@ You should also see monitoring and traces from Wavefront under the application n
 
 ## Starting services locally without Docker
 
-Every microservice is a Spring Boot application and can be started locally using IDE or `../mvnw spring-boot:run` command. Please note that supporting services (Config and Discovery Server) must be started before any other application (Customers, Vets, Visits and API).
+Every microservice is a Spring Boot application and can be started locally using IDE 
+or `../mvnw spring-boot:run -Plocal` command.
+Remember to enable the `local` Maven profile.
+
+Please note that supporting services (Config and Discovery Server) must be started before any other application (Customers, Vets, Visits and API).
 Startup of Tracing server, Admin server, Grafana and Prometheus is optional.
 If everything goes well, you can access the following services at given location:
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 
 	<groupId>org.springframework.samples</groupId>
 	<artifactId>spring-petclinic-cloud</artifactId>
-	<version>2.3.1</version>
 	<name>${project.artifactId}</name>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.6.3</version>
 	</parent>
 
 	<groupId>org.springframework.samples</groupId>
@@ -126,36 +126,5 @@
 			</build>
 		</profile>
 	</profiles>
-
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 </project>

--- a/spring-petclinic-admin-server/pom.xml
+++ b/spring-petclinic-admin-server/pom.xml
@@ -12,14 +12,15 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.6.3</version>
         <relativePath/>
     </parent>
     <properties>
-        <spring-boot-admin.version>2.2.2</spring-boot-admin.version>
-        <spring-cloud.version>Hoxton.SR6</spring-cloud.version>
-        <spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-admin-server</spring-boot.build-image.imageName>
+        <spring-boot-admin.version>2.5.5</spring-boot-admin.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
 
+        <spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-admin-server</spring-boot.build-image.imageName>
     </properties>
 
     <dependencies>
@@ -61,7 +62,7 @@
             <dependency>
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-services-dependencies</artifactId>
-                <version>3.1.2.RELEASE</version>
+                <version>${spring-cloud-services.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -72,24 +73,6 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring-boot.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
             </dependency>
 
         </dependencies>

--- a/spring-petclinic-admin-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-admin-server/src/main/resources/bootstrap.yml
@@ -6,7 +6,10 @@ spring:
     name: admin-server
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
+

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.6.3</version>
 		<relativePath/>
 	</parent>
 
@@ -20,9 +20,10 @@
 		<java.version>11</java.version>
 		<assertj.version>3.11.1</assertj.version>
 
-		<spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
-		<wavefront.version>2.0.1-SNAPSHOT</wavefront.version>
+		<spring-boot.version>2.6.3</spring-boot.version>
+		<spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
+		<wavefront.version>2.2.2</wavefront.version>
 
 		<maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
 
@@ -73,6 +74,10 @@
 		</dependency>
 
 		<!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
@@ -158,7 +163,7 @@
 			<dependency>
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-dependencies</artifactId>
-				<version>3.1.2.RELEASE</version>
+				<version>${spring-cloud-services.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -177,18 +182,6 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-test</artifactId>
-				<version>${spring-boot.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
@@ -342,40 +335,10 @@
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.cloud</groupId>
-					<artifactId>spring-cloud-starter-kubernetes-all</artifactId>
+					<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
 	</profiles>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 </project>

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -260,7 +260,6 @@
 	</build>
 
 	<profiles>
-
 		<profile>
 			<id>local</id>
 			<dependencies>
@@ -328,14 +327,14 @@
 
 
 		<profile>
-			<id>kubernetes</id>
+			<id>k8s</id>
 	        <activation>
 	            <activeByDefault>true</activeByDefault>
 	        </activation>
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.cloud</groupId>
-					<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+					<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
@@ -12,13 +12,17 @@ management:
         apiToken: ""
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
 ---
 spring:
-  profiles: kubernetes
+  config:
+    activate:
+      on-profile: kubernetes
   cloud:
     config:
       enabled: false

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/boundary/web/ApiGatewayControllerTest.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/boundary/web/ApiGatewayControllerTest.java
@@ -1,13 +1,11 @@
 package org.springframework.samples.petclinic.api.boundary.web;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.circuitbreaker.resilience4j.ReactiveResilience4JAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.samples.petclinic.api.application.CustomersServiceClient;
 import org.springframework.samples.petclinic.api.application.VisitsServiceClient;
@@ -15,16 +13,14 @@ import org.springframework.samples.petclinic.api.dto.OwnerDetails;
 import org.springframework.samples.petclinic.api.dto.PetDetails;
 import org.springframework.samples.petclinic.api.dto.VisitDetails;
 import org.springframework.samples.petclinic.api.dto.Visits;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
 import java.net.ConnectException;
 import java.util.Collections;
 
-@ExtendWith(SpringExtension.class)
 @WebFluxTest(controllers = ApiGatewayController.class)
-@Import({ReactiveResilience4JAutoConfiguration.class, InsecurityConfiguration.class})
+@Import({ReactiveResilience4JAutoConfiguration.class, CircuitBreakerConfiguration.class, InsecurityConfiguration.class})
 class ApiGatewayControllerTest {
 
 	@MockBean

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/boundary/web/CircuitBreakerConfiguration.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/boundary/web/CircuitBreakerConfiguration.java
@@ -1,0 +1,20 @@
+package org.springframework.samples.petclinic.api.boundary.web;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CircuitBreakerConfiguration {
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry() {
+        return CircuitBreakerRegistry.ofDefaults();
+    }
+
+    @Bean
+    public TimeLimiterRegistry timeLimiterRegistry() {
+        return TimeLimiterRegistry.ofDefaults();
+    }
+}

--- a/spring-petclinic-config-server/pom.xml
+++ b/spring-petclinic-config-server/pom.xml
@@ -11,13 +11,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.6.3</version>
         <relativePath/>
     </parent>
 
     <properties>
         <spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-config-server</spring-boot.build-image.imageName>
-        <spring-cloud.version>Hoxton.SR6</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
     </properties>
 
 	<dependencies>
@@ -29,6 +30,10 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-config-server</artifactId>
@@ -57,7 +62,7 @@
             <dependency>
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-services-dependencies</artifactId>
-                <version>3.1.2.RELEASE</version>
+                <version>${spring-cloud-services.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -68,18 +73,6 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring-boot.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/spring-petclinic-config-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-config-server/src/main/resources/bootstrap.yml
@@ -4,7 +4,7 @@ spring:
     config:
       server:
         git:
-          uri: https://github.com/spring-petclinic/spring-petclinic-microservices-config
+          uri: https://github.com/spring-petclinic/spring-petclinic-cloud-config
         # Use the File System Backend to avoid git pulling. Enable "native" profile in the Config Server.
         native:
           searchLocations: file:///${GIT_REPO}

--- a/spring-petclinic-customers-service/pom.xml
+++ b/spring-petclinic-customers-service/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.6.3</version>
 		<relativePath/>
 	</parent>
 
@@ -21,13 +21,14 @@
 		<java.version>11</java.version>
 		<assertj.version>3.11.1</assertj.version>
 
-		<spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-		<spring-cloud.version>Hoxton.SR5</spring-cloud.version>
-		<wavefront.version>2.0.1-SNAPSHOT</wavefront.version>
+		<spring-boot.version>2.6.3</spring-boot.version>
+		<spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
+        <wavefront.version>2.2.2</wavefront.version>
 
-		<maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-		<spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-customers-service</spring-boot.build-image.imageName>
-	</properties>
+        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
+        <spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-customers-service</spring-boot.build-image.imageName>
+    </properties>
 
 	<dependencies>
 
@@ -69,6 +70,10 @@
 		</dependency>
 
 		<!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -125,7 +130,7 @@
 			<dependency>
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-dependencies</artifactId>
-				<version>3.1.2.RELEASE</version>
+				<version>${spring-cloud-services.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -144,18 +149,6 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-test</artifactId>
-				<version>${spring-boot.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
@@ -241,7 +234,7 @@
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.cloud</groupId>
-					<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+					<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
@@ -279,34 +272,4 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 </project>

--- a/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
@@ -6,13 +6,17 @@ spring:
     name: customers-service
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
 ---
 spring:
-  profiles: kubernetes
+  config:
+    activate:
+      on-profile: kubernetes
   cloud:
     config:
       enabled: false
@@ -29,7 +33,9 @@ management:
       enabled: true
 ---
 spring:
-  profiles: tas4k8s
+  config:
+    activate:
+      on-profile: tas4k8s
   cloud:
     config:
       enabled: false

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Maciej Szarlinski
  */
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(PetResource.class)
 @ActiveProfiles("test")
 class PetResourceTest {

--- a/spring-petclinic-customers-service/src/test/resources/application-test.yml
+++ b/spring-petclinic-customers-service/src/test/resources/application-test.yml
@@ -1,9 +1,10 @@
 spring.jpa.hibernate.ddl-auto: none
 
 spring:
-  datasource:
-    schema: classpath*:db/hsqldb/schema.sql
-    data: classpath*:db/hsqldb/data.sql
+  sql:
+    init:
+      schema-locations: classpath*:db/hsqldb/schema.sql
+      data-locations: classpath*:db/hsqldb/data.sql
 
 logging.level.org.springframework: INFO
 

--- a/spring-petclinic-discovery-server/pom.xml
+++ b/spring-petclinic-discovery-server/pom.xml
@@ -11,13 +11,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.6.3</version>
         <relativePath/>
     </parent>
 
     <properties>
         <spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-discovery-service</spring-boot.build-image.imageName>
-        <spring-cloud.version>Hoxton.SR6</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
     </properties>
 
     <dependencies>
@@ -29,6 +30,10 @@
         </dependency>
 
         <!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
@@ -61,7 +66,7 @@
             <dependency>
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-services-dependencies</artifactId>
-                <version>3.1.2.RELEASE</version>
+                <version>${spring-cloud-services.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -72,18 +77,6 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring-boot.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/spring-petclinic-discovery-server/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-discovery-server/src/main/resources/bootstrap.yml
@@ -6,7 +6,10 @@ spring:
     name: discovery-server
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
+

--- a/spring-petclinic-vets-service/pom.xml
+++ b/spring-petclinic-vets-service/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.6.3</version>
 		<relativePath/>
 	</parent>
 
@@ -20,9 +20,10 @@
 		<java.version>11</java.version>
 		<assertj.version>3.11.1</assertj.version>
 
-		<spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
-		<wavefront.version>2.0.1-SNAPSHOT</wavefront.version>
+		<spring-boot.version>2.6.3</spring-boot.version>
+		<spring-cloud.version>2021.0.0</spring-cloud.version>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
+		<wavefront.version>2.2.2</wavefront.version>
 
 		<maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
 
@@ -77,6 +78,10 @@
 		</dependency>
 
 		<!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -137,7 +142,7 @@
 			<dependency>
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-dependencies</artifactId>
-				<version>3.1.2.RELEASE</version>
+				<version>${spring-cloud-services.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -156,18 +161,6 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-test</artifactId>
-				<version>${spring-boot.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
@@ -286,41 +279,10 @@
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.cloud</groupId>
-					<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+					<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
 	</profiles>
-
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 </project>

--- a/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
@@ -6,13 +6,17 @@ spring:
     name: vets-service
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
 ---
 spring:
-  profiles: kubernetes
+  config:
+    activate:
+      on-profile: kubernetes
   cloud:
     config:
       enabled: false
@@ -29,7 +33,9 @@ management:
       enabled: true
 ---
 spring:
-  profiles: tas4k8s
+  config:
+    activate:
+      on-profile: tas4k8s
   cloud:
     config:
       enabled: false

--- a/spring-petclinic-visits-service/pom.xml
+++ b/spring-petclinic-visits-service/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.6.3</version>
 		<relativePath/>
 	</parent>
 
@@ -20,12 +20,13 @@
 		<java.version>11</java.version>
 		<assertj.version>3.11.1</assertj.version>
 		<maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-		<spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
-		<wavefront.version>2.0.1-SNAPSHOT</wavefront.version>
+		<spring-boot.version>2.6.3</spring-boot.version>
+		<spring-cloud.version>2021.0.0</spring-cloud.version>
+		<wavefront.version>2.2.2</wavefront.version>
 
 		<spring-boot.build-image.imageName>${REPOSITORY_PREFIX}/spring-petclinic-cloud-visits-service</spring-boot.build-image.imageName>
-	</properties>
+        <spring-cloud-services.version>3.3.0</spring-cloud-services.version>
+    </properties>
 
 	<dependencies>
 		<!-- Spring Boot -->
@@ -66,6 +67,10 @@
 		</dependency>
 
 		<!-- Spring Cloud -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -116,7 +121,7 @@
 			<dependency>
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-dependencies</artifactId>
-				<version>3.1.2.RELEASE</version>
+				<version>${spring-cloud-services.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -135,18 +140,6 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-test</artifactId>
-				<version>${spring-boot.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
@@ -264,41 +257,11 @@
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.cloud</groupId>
-					<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+					<artifactId>spring-cloud-starter-kubernetes-client-config</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
 	</profiles>
 
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 </project>

--- a/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
@@ -6,13 +6,17 @@ spring:
     name: visits-service
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       uri: http://config-server:8888
 ---
 spring:
-  profiles: kubernetes
+  config:
+    activate:
+      on-profile: kubernetes
   cloud:
     config:
       enabled: false
@@ -29,7 +33,9 @@ management:
       enabled: true
 ---
 spring:
-  profiles: tas4k8s
+  config:
+    activate:
+      on-profile: tas4k8s
   cloud:
     config:
       enabled: false


### PR DESCRIPTION
This PR upgrade to Spring Cloud 2021.0.0 and Spring Boot 2.6.3 without removing the Spring Cloud's bootstrap context.
The application is working locally and in k8s:
![image](https://user-images.githubusercontent.com/838318/152687548-ba315f9b-6bae-47c5-9015-47e337146009.png)
